### PR TITLE
feat: add glob override

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,3 +142,11 @@ If a snapshot is filled with primitives with no props it is likely that either
 there are too many of them in general or the test isn't specific enough. For
 example 15 `div` elements suggest a lot of "div noise" rather than a specific
 render test
+
+## Additional config options
+
+### snapPattern: string
+
+**default**: \*\*/\*.js.snap
+
+This is relative to the `cwd`

--- a/main.ts
+++ b/main.ts
@@ -5,10 +5,10 @@ import report from "./report";
 import writer from "./console";
 import { Options, Dir } from "./types";
 
-const getSnapshots = (cwd: Dir) =>
+const getSnapshots = (cwd: Dir, snapPattern?: string) =>
   new Promise<string[]>((res, rej) => {
     glob(
-      "**/*.js.snap",
+      snapPattern || "**/*.js.snap",
       {
         cwd,
         ignore: ["**/node_modules/**"]
@@ -28,7 +28,7 @@ const getSnapshots = (cwd: Dir) =>
   });
 
 export default async (cwd: Dir, opts: Options) => {
-  const snapshots = await getSnapshots(cwd);
+  const snapshots = await getSnapshots(cwd, opts.snapPattern);
 
   const results = await Promise.all(snapshots.map(analyse));
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,7 @@
 import { AST } from "acorn-jsx";
 
 export interface Options {
+  snapPattern?: string;
   maxFileSize?: number;
   genericAttributes?: string[];
   genericValues?: string[];


### PR DESCRIPTION
Rather than predefining the glob pattern to match on snap files, allow the consumer to provide theirs through the normal `.jestlint` config as `snapPattern`