### PR TITLE
refactor: amend default maxAttributeStringLength

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -39,7 +39,7 @@ export default async (cwd: Dir, opts: Options) => {
     genericValues: opts.genericValues || ["[Function]"],
     maxAttr: opts.maxAttributes || 5,
     maxAttrArrayLength: opts.maxAttributeArrayLength || 5,
-    maxAttrStringLength: opts.maxAttributeStringLength || 30,
+    maxAttrStringLength: opts.maxAttributeStringLength || 32,
     maxDepth: opts.maxDepth || 10,
     maxFileSize: opts.maxFileSize || 10000,
     maxGenericElement: opts.maxGenericElements || 10,


### PR DESCRIPTION
There is a pattern in Times Components where hashing long snapshot attributes make them a 32byte hash, so it makes sense to make 32 the default string length value so we don't have to override with config in each TC package