### PR TITLE
fix: catch error

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -25,6 +25,12 @@ readFile(path.join(process.cwd(), ".jestlint"), "utf8")
       ...JSON.parse(contents),
       usingCI: ci,
       isVerbose: verbose
+    }).catch(e => {
+      if (verbose) {
+        console.log(e);
+      }
+
+      process.exit(1);
     })
   )
   .catch(() => {


### PR DESCRIPTION
the original catch was for the non-existence of a  `.jestlint` config. Now that `main` throws when it has error, these should be caught separately for clarity and prevent re-running the analyses